### PR TITLE
fix:ユーザー登録時にnameカラムを追加。buffsテーブルのレコードも同時に生成されるよう追記

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -9,6 +9,12 @@
 @import "header";
 @import "footer";
 
+
+.container {
+    text-align: center;
+    font-size: 24px;
+}
+
 .back_color {
     background-color: white;
 }

--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -19,11 +19,6 @@
     margin-right: 10px;
 }
 
-.container {
-    text-align: center;
-    font-size: 24px;
-}
-
 .btn {
     background: green; /* 背景色 */
     color: #fff; /* 文字色 */

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
@@ -10,9 +10,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    super do |user|
+      if user.persisted?
+        # ユーザーが正常に作成された場合
+        random_buff = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].sample
+        Buff.create(user_id: user.id, sum_buff: random_buff)
+      end
+    end 
+  end
 
   # GET /resource/edit
   # def edit
@@ -41,9 +47,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_one :buffs, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 255 }
 end

--- a/app/views/users/registrations/_new_form.html.erb
+++ b/app/views/users/registrations/_new_form.html.erb
@@ -1,6 +1,12 @@
+<h1>Sign up</h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+  </div>
 
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,32 +1,3 @@
-<h1>Sign up</h1>
-
-<div class='form'>
-  <%= render 'new' %>
+<div class='container'>
+  <%= render 'new_form' %>
 </div>
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>

--- a/app/views/users/sessions/_login_form.html.erb
+++ b/app/views/users/sessions/_login_form.html.erb
@@ -1,0 +1,28 @@
+<div class='container'>
+  <h2>Log in</h2>
+
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password %><br />
+      <%= f.password_field :password, autocomplete: "current-password" %>
+    </div>
+
+    <% if devise_mapping.rememberable? %>
+      <div class="field">
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me %>
+      </div>
+    <% end %>
+
+    <div class="actions">
+      <%= f.submit "Log in" %>
+    </div>
+  <% end %>
+
+  <%= render "users/shared/links" %>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,3 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+<div class='container'>
+  <%= render 'login_form' %>
+</div>

--- a/db/migrate/20240615232100_add_column_to_users.rb
+++ b/db/migrate/20240615232100_add_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_15_160849) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_15_232100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_15_160849) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
* Userモデルにnameカラムを追加
* registrationsコントローラーのcreateメソッドにて、nameカラムも追加するようストロングパラメータの修正メソッドを追記(before_action)
* registrationsコントローラーのcreateメソッドにて、usersへの登録完了後に、user_idに関連付けたbuffsテーブルのレコード作成処理を記述。(sum_buffに10から100までのランダムな数値を入力)
* ユーザー登録時にnameが追加されていることと、buffsテーブルのレコードが追加されていることをコンテナログにて確認

<img width="965" alt="image" src="https://github.com/ryusuke-goto/likedama/assets/151528192/43d76ec5-30e1-424f-a098-a4e7ddc7afd9">


close #5 