### PR TITLE
fontawesomeのgem関係を削除。headタグに追加する方法でfontawesomeを使ったハート表示。ヘッダーに戦闘力参照機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,5 +74,3 @@ gem 'devise'
 gem 'rails-i18n'
 
 gem 'devise-i18n-views'
-
-gem "font-awesome-sass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,14 +111,6 @@ GEM
     devise-i18n-views (0.3.7)
     drb (2.2.1)
     erubi (1.12.0)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-arm-linux-gnu)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86-linux-gnu)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
-    font-awesome-sass (6.5.2)
-      sassc (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
@@ -228,8 +220,6 @@ GEM
     rexml (3.3.0)
       strscan
     rubyzip (2.3.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     selenium-webdriver (4.21.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
@@ -285,7 +275,6 @@ DEPENDENCIES
   debug
   devise
   devise-i18n-views
-  font-awesome-sass
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -10,8 +10,6 @@
 @import "footer";
 @import "diary";
 
-@import "font-awesome";
-
 .alert-notice {
     background-color: rgb(17, 203, 141);
     color: black;

--- a/app/assets/stylesheets/diary.css
+++ b/app/assets/stylesheets/diary.css
@@ -1,3 +1,4 @@
-.diaries {
-    text-align: center;
+.card-likes {
+    width: 100px;
+    height: 100px;
 }

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -2,25 +2,27 @@
 <div class="px-3.5">
   <div id="diary-id-<%= diary.id %>">
     <div class="card w-96 bg-base-100 shadow-xl">
-        <div class="flex">
-          <%= image_tag "diary_placeholder.png", class: "card-img-top", width: "100", height:"100" %>
-        </div>
-        <div class="card-body items-center text-center">
-            <div class="diaries  card-title">
+        <%= image_tag "diary_placeholder.png", class: "card-img-top", width: "100", height:"100" %>
+        <div class="card-body">
+            <div class="card-title">
                 <%= link_to diary.title, '#' %>
             </div>
             <div class="card-text">
                 <p><%= diary.body %></p>
             </div>
-            <% if Like.record_find(user: current_user.id, diary: diary.id) %>
-                <%= link_to like_path(Like.record_find(user: current_user.id, diary: diary.id)), data: { turbo_method: :patch }, id: 'like-#{diary.id}' do %>
-                    <%= Like.likes_count(diary.id) || 0 %>
+            <div class="flex">
+                <% if Like.record_find(user: current_user.id, diary: diary.id) %>
+                    <%= link_to like_path(Like.record_find(user: current_user.id, diary: diary.id)), data: { turbo_method: :patch }, id: 'like-#{diary.id}' do %>
+                      <i class="fa-solid fa-heart"></i>  
+                      <%= Like.likes_count(diary.id) || 0 %>
+                    <% end %>
+                <% else %>
+                    <%= link_to likes_path(diary_id: diary.id), data: { turbo_method: :post }, id: 'like-#{diary.id}' do %>
+                      <i class="fa-solid fa-heart"></i>
+                      <%= Like.likes_count(diary.id) || 0 %>
+                    <% end %>
                 <% end %>
-            <% else %>
-                <%= link_to likes_path(diary_id: diary.id), data: { turbo_method: :post }, id: 'like-#{diary.id}' do %>
-                    <%= Like.likes_count(diary.id) || 0 %>
-                <% end %>
-            <% end %>
+            </div>
             <ul class="list-inline">
                 <li><i class="bi bi-person"></i><%= diary.user.name %></li>
                 <li><i class="bi bi-calendar"></i><%= l diary.created_at, format: :short %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="cupcake">
   <head>
     <title>Likedama</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <script src="https://kit.fontawesome.com/d7bfabcd52.js" crossorigin="anonymous"></script>
   </head>
 
   <body class="flex flex-col min-h-screen back_color">

--- a/app/views/likes/update.turbo.html.erb
+++ b/app/views/likes/update.turbo.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "like-#{diary.id}" do %>
+
+<% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,4 @@
 <footer id='footer' class='footer-bottom'>
   <div class='container'>
-          <p>フッター</p>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,12 @@
 
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
       <ul class='ms-auto flex justify-between'>
+        <li class='nav-item flex'>
+          <%= t('header.user_power') %>
+          <h1>
+            <%= current_user.buff.sum_buff %>
+          </h1>
+        </li>
         <li class='nav-item'>
           <%= link_to t('header.diary_index'), diaries_path, class: '' %>
         </li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,6 +22,7 @@ ja:
       link: ユーザー登録はこちら
   header:
     title: いいね玉
+    user_power: あなたの戦闘力は
     login: ログイン
     logout: ログアウト
     diary_index: 日記を見に行く

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,4 +6,7 @@ module.exports = {
     './app/javascript/**/*.js'
   ],
   plugins: [require("daisyui")],
+  daisyui: {
+    themes: ["light", "dark", "cupcake"],
+  },  
 }


### PR DESCRIPTION
## 概要
* Gemfileのgem 'font-awesome'削除後、application_tailwind.cssの@import 'font-awesome'削除
* bundle install実行
* fontawesomeのアカウントを作成し、キットを使用できるようにするリンクを入手。ビューファイルのheadタグに追加することでハート表示成功
* ログイン後のヘッダーにユーザーの戦闘力表示機能追加

close #21 
